### PR TITLE
Update for nullable FormKey systems

### DIFF
--- a/AIOverhaulPatcher/AIOverhaulPatcher.csproj
+++ b/AIOverhaulPatcher/AIOverhaulPatcher.csproj
@@ -4,8 +4,8 @@
 				<TargetFramework>netcoreapp3.1</TargetFramework>
 		</PropertyGroup>
 		<ItemGroup>
-			<PackageReference Include="Mutagen.Bethesda" Version="0.21.6" />
-			<PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.11.1" />
+			<PackageReference Include="Mutagen.Bethesda" Version="0.22.1" />
+			<PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.12.1" />
 			<PackageReference Include="Mutagen.Bethesda.FormKeys.SkyrimSE" Version="1.0.0" />
 		</ItemGroup>
 </Project>

--- a/AIOverhaulPatcher/Program.cs
+++ b/AIOverhaulPatcher/Program.cs
@@ -95,11 +95,11 @@ namespace AIOverhaulPatcher
                     PackagesToAdd.ForEach(x => patchNpc.Packages.Add(x));
 
 
-                    var OverwrittenOutfits = Masters.Select(x => x.DefaultOutfit).Select(x => x.FormKey.HasValue ? x.FormKey.Value.ID : 0).Distinct().ToList();
-                    var OverwrittenSleepingOutfit = Masters.Select(x => x.SleepingOutfit).Select(x => x.FormKey.HasValue ? x.FormKey.Value.ID : 0).Distinct().ToList();
+                    var OverwrittenOutfits = Masters.Select(x => x.DefaultOutfit).Select(x => x.FormKeyNullable.HasValue ? x.FormKeyNullable.Value.ID : 0).Distinct().ToList();
+                    var OverwrittenSleepingOutfit = Masters.Select(x => x.SleepingOutfit).Select(x => x.FormKeyNullable.HasValue ? x.FormKeyNullable.Value.ID : 0).Distinct().ToList();
 
-                    FormKey? OverwrittingOutfit = overrides.Select(x => x.DefaultOutfit).Select(x => x.FormKey).Where(x => x != null && !OverwrittenOutfits.Contains(x.Value.ID)).Prepend(npc.DefaultOutfit.FormKey).Last();
-                    FormKey? OverwrittingSleepingOutfit = overrides.Select(x => x.SleepingOutfit).Select(x => x.FormKey).Where(x => x != null && !OverwrittenSleepingOutfit.Contains(x.Value.ID)).Prepend(npc.SleepingOutfit.FormKey).Last();
+                    FormKey? OverwrittingOutfit = overrides.Select(x => x.DefaultOutfit).Select(x => x.FormKeyNullable).Where(x => x != null && !OverwrittenOutfits.Contains(x.Value.ID)).Prepend(npc.DefaultOutfit.FormKey).Last();
+                    FormKey? OverwrittingSleepingOutfit = overrides.Select(x => x.SleepingOutfit).Select(x => x.FormKeyNullable).Where(x => x != null && !OverwrittenSleepingOutfit.Contains(x.Value.ID)).Prepend(npc.SleepingOutfit.FormKey).Last();
 
                     patchNpc.DefaultOutfit = OverwrittingOutfit;
                     patchNpc.SleepingOutfit = OverwrittingSleepingOutfit;


### PR DESCRIPTION
Updated the FormKey nullability systems a bit.
`FormLink` had `FormKey` member.  It could either contain a legit value, or FormKey.Null (all zeros).
`FormLinkNullable` had a `FormKey?` member, which is as above, but could also be null to represent that it didn't exist at all whatsoever on-disk.

FormLinkNullable now offers both:
`FormKey FormKey { get; }`
AND
`FormKey? FormKeyNullable { get; }`

What this means is that FormKeyNullable member can be checked if you care to know if the member existed at all or not.
The FormKey member, then, is a convenience call which is essentially checks if it's null and just returns FormKey.Null if it was:
`return FormKeyNullable ?? FormKey.Null`

Simplifies usage a little bit going forward, but was a breaking change.